### PR TITLE
feat: add gemini emojies before route names

### DIFF
--- a/BusStopNotifier.xcodeproj/project.pbxproj
+++ b/BusStopNotifier.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		3FBE39A42CA2C6E000F8FC43 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE39A32CA2C6E000F8FC43 /* SettingsView.swift */; };
 		3FBE39A62CA30A2E00F8FC43 /* RouteSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE39A52CA30A2E00F8FC43 /* RouteSettingsView.swift */; };
 		3FBE39A92CA34E3300F8FC43 /* RouteActivationPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE39A82CA34E3300F8FC43 /* RouteActivationPeriod.swift */; };
+		3FD84F782CAD901F00D1BA11 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 3FD84F772CAD901F00D1BA11 /* Alamofire */; };
 		3FECF26D2C5F476A00B935F0 /* BusStopNotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FECF26C2C5F476A00B935F0 /* BusStopNotifierApp.swift */; };
 		3FECF2712C5F476B00B935F0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FECF2702C5F476B00B935F0 /* Assets.xcassets */; };
 		3FECF2742C5F476B00B935F0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FECF2732C5F476B00B935F0 /* Preview Assets.xcassets */; };
@@ -67,6 +68,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FECF2862C5F5EEC00B935F0 /* Lottie in Frameworks */,
+				3FD84F782CAD901F00D1BA11 /* Alamofire in Frameworks */,
 				3F4AA1E92C7730C6000E7E60 /* GooglePlaces in Frameworks */,
 				3F4AA1EC2C7730D8000E7E60 /* GoogleMaps in Frameworks */,
 			);
@@ -285,6 +287,7 @@
 				3FECF2852C5F5EEC00B935F0 /* Lottie */,
 				3F4AA1E82C7730C6000E7E60 /* GooglePlaces */,
 				3F4AA1EB2C7730D8000E7E60 /* GoogleMaps */,
+				3FD84F772CAD901F00D1BA11 /* Alamofire */,
 			);
 			productName = BusStopNotifier;
 			productReference = 3FECF2692C5F476A00B935F0 /* BusStopNotifier.app */;
@@ -318,6 +321,7 @@
 				3FECF2842C5F5EEC00B935F0 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				3F4AA1E72C7730C6000E7E60 /* XCRemoteSwiftPackageReference "ios-places-sdk" */,
 				3F4AA1EA2C7730D8000E7E60 /* XCRemoteSwiftPackageReference "ios-maps-sdk" */,
+				3FD84F762CAD901F00D1BA11 /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
 			productRefGroup = 3FECF26A2C5F476A00B935F0 /* Products */;
 			projectDirPath = "";
@@ -600,6 +604,14 @@
 				minimumVersion = 9.1.0;
 			};
 		};
+		3FD84F762CAD901F00D1BA11 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.9.1;
+			};
+		};
 		3FECF2842C5F5EEC00B935F0 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios";
@@ -620,6 +632,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F4AA1EA2C7730D8000E7E60 /* XCRemoteSwiftPackageReference "ios-maps-sdk" */;
 			productName = GoogleMaps;
+		};
+		3FD84F772CAD901F00D1BA11 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FD84F762CAD901F00D1BA11 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
 		};
 		3FECF2852C5F5EEC00B935F0 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BusStopNotifier.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BusStopNotifier.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,15 @@
 {
+  "originHash" : "47288454e4292a153cc4e480d19c9c36caceebce1fb0619bd514d44de5bd1292",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
     {
       "identity" : "ios-maps-sdk",
       "kind" : "remoteSourceControl",
@@ -28,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/BusStopNotifier/Features/MainPage/Views/HomeView.swift
+++ b/BusStopNotifier/Features/MainPage/Views/HomeView.swift
@@ -33,7 +33,7 @@ struct HomeView: View {
 //                                    .navigationBarBackButtonHidden()
                             } label: {
                                 HStack {
-                                    Text(route.name)
+                                    Text("\(route.emoji) \(route.name)")
                                     Spacer()
                                     Text(route.isActive ? "Active" : "Inactive")
                                         .font(.caption)
@@ -92,12 +92,14 @@ struct HomeView: View {
             .alert("Enter the route name", isPresented: $showAlert) {
                 TextField("Route name", text: $routeName)
                 Button("Add") {
-                    let newRoute = Route(name: routeName, places: [], isActive: true, activationPeriodType: .singleDay)
-                    viewModel.routes.append(newRoute)
-                    viewModel.saveRoutes()
-                    selectedRoute = newRoute
-                    routeName = ""
-                    showAddRoutes = true
+                    viewModel.generateEmoji(for: routeName) { emoji in
+                        let newRoute = Route(name: routeName, places: [], isActive: true, emoji: emoji, activationPeriodType: .singleDay)
+                        viewModel.routes.append(newRoute)
+                        viewModel.saveRoutes()
+                        selectedRoute = newRoute
+                        showAddRoutes = true
+                        routeName = ""
+                    }
                 }
                 Button("Cancel", role: .cancel) {
                     routeName = ""

--- a/BusStopNotifier/Features/Map/Views/MapView.swift
+++ b/BusStopNotifier/Features/Map/Views/MapView.swift
@@ -35,5 +35,5 @@ struct MapView: View {
 }
 
 #Preview {
-    MapView(route: Route(name: "", places: [], isActive: true, activationPeriodType: .singleDay))
+    MapView(route: Route(name: "", places: [], isActive: true, emoji: "🤖", activationPeriodType: .singleDay))
 }

--- a/BusStopNotifier/Features/Map/Views/MapViewController.swift
+++ b/BusStopNotifier/Features/Map/Views/MapViewController.swift
@@ -11,7 +11,7 @@ import CoreLocation
 import GoogleMaps
 import GooglePlaces
 
-class MapViewController: UIViewController{
+class MapViewController: UIViewController {
     
     var mapView: GMSMapView?
     var resultsViewController: GMSAutocompleteResultsViewController?
@@ -186,4 +186,31 @@ extension MapViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
             print("Error: \(error.localizedDescription)")
         }
+    func didTapMyLocationButton(for mapView: GMSMapView) -> Bool {
+        let authorizationStatus = locationManager.authorizationStatus
+        if authorizationStatus == .denied || authorizationStatus == .restricted {
+            showLocationAccessDeniedAlert()
+        }
+        return true
+    }
+    
+    func showLocationAccessDeniedAlert() {
+            let alertController = UIAlertController(
+                title: "Location Access Denied",
+                message: "Please enable location access in Settings to use this feature.",
+                preferredStyle: .alert
+            )
+            let settingsAction = UIAlertAction(title: "Settings", style: .default) { _ in
+                if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(appSettings)
+                }
+            }
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+            
+            alertController.addAction(settingsAction)
+            alertController.addAction(cancelAction)
+            
+            present(alertController, animated: true, completion: nil)
+        }
+    
 }

--- a/BusStopNotifier/Features/Route/Models/Route.swift
+++ b/BusStopNotifier/Features/Route/Models/Route.swift
@@ -13,16 +13,18 @@ class Route: ObservableObject, Identifiable, Equatable, Hashable, Codable {
     @Published var name: String
     @Published var places: [Place]
     @Published var isActive: Bool
+    @Published var emoji: String
     var activationPeriodType: RouteActivationPeriod
     private var dailyTimer: DispatchSourceTimer?
     
     
     
-    init(name: String, places: [Place] = [], isActive: Bool, activationPeriodType: RouteActivationPeriod) {
+    init(name: String, places: [Place] = [], isActive: Bool, emoji: String, activationPeriodType: RouteActivationPeriod) {
         self.name = name
         self.places = places
         self.isActive = isActive
         self.activationPeriodType = activationPeriodType
+        self.emoji = emoji
         
         setupDailyTimer()
     }
@@ -97,7 +99,7 @@ class Route: ObservableObject, Identifiable, Equatable, Hashable, Codable {
     
     // MARK: - Codable Conformance
     enum CodingKeys: String, CodingKey {
-        case id, name, places, isActive, activationPeriodType
+        case id, name, places, isActive, emoji, activationPeriodType
     }
     
     required init(from decoder: Decoder) throws {
@@ -106,6 +108,7 @@ class Route: ObservableObject, Identifiable, Equatable, Hashable, Codable {
         name = try container.decode(String.self, forKey: .name)
         places = try container.decode([Place].self, forKey: .places)
         isActive = try container.decode(Bool.self, forKey: .isActive)
+        emoji = try container.decode(String.self, forKey: .emoji)
         activationPeriodType = try container.decode(RouteActivationPeriod.self, forKey: .activationPeriodType)
         
         setupDailyTimer()
@@ -118,6 +121,7 @@ class Route: ObservableObject, Identifiable, Equatable, Hashable, Codable {
         try container.encode(name, forKey: .name)
         try container.encode(places, forKey: .places)
         try container.encode(isActive, forKey: .isActive)
+        try container.encode(emoji, forKey: .emoji)
         try container.encode(activationPeriodType, forKey: .activationPeriodType)
         
     }

--- a/BusStopNotifier/Features/Route/Views/RouteSettingsView.swift
+++ b/BusStopNotifier/Features/Route/Views/RouteSettingsView.swift
@@ -44,5 +44,5 @@ struct RouteSettingsView: View {
 }
 
 #Preview {
-    RouteSettingsView(route: Route(name: "", places: [], isActive: true, activationPeriodType: .singleDay))
+    RouteSettingsView(route: Route(name: "", places: [], isActive: true, emoji: "🤖", activationPeriodType: .singleDay))
 }

--- a/BusStopNotifier/Features/Route/Views/RouteView.swift
+++ b/BusStopNotifier/Features/Route/Views/RouteView.swift
@@ -110,5 +110,5 @@ struct RouteView: View {
 }
 
 #Preview {
-    RouteView(route: Route(name: "", places: [], isActive: true, activationPeriodType: .singleDay))
+    RouteView(route: Route(name: "", places: [], isActive: true, emoji: "🤖", activationPeriodType: .singleDay))
 }

--- a/BusStopNotifier/Others/apiKeys.swift
+++ b/BusStopNotifier/Others/apiKeys.swift
@@ -8,3 +8,4 @@
 import Foundation
 
 let googleApiKey = "AIzaSyDtxTFTE0vDtN6AjCeYtPpCvRRY4Fm8dzA"
+let geminiApiKey = "AIzaSyA-janH1oBdd-o_3EVUvs2BaSQbznOnouQ"

--- a/BusStopNotifier/Services/Call.swift
+++ b/BusStopNotifier/Services/Call.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import CallKit
+import AVFoundation
+
 
 class CallService: NSObject, CXProviderDelegate {
     func providerDidReset(_ provider: CXProvider) {
@@ -15,6 +17,7 @@ class CallService: NSObject, CXProviderDelegate {
     static let shared = CallService()
     private let provider: CXProvider
     private let callController = CXCallController()
+    private let speechSynthesizer = AVSpeechSynthesizer()
     
     override init() {
         
@@ -32,10 +35,19 @@ class CallService: NSObject, CXProviderDelegate {
             if let error = error {
                 print("Error reporting incoming call: \(error.localizedDescription)")
             } else {
-                
+                self.announceArrival()
             }
         }
     }
+    
+    private func announceArrival() {
+        let utterance = AVSpeechUtterance(string: "You have arrived to your destination!")
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        speechSynthesizer.speak(utterance)
+    }
+    
+    
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         let endCallAction = CXEndCallAction(call: action.callUUID)
         let transaction = CXTransaction(action: endCallAction)


### PR DESCRIPTION
- Cases when the permission for notification and location is not granted handled
- The destination name when calling are now specified
- Added emoji before route title